### PR TITLE
Updated r.json to R 3.2.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+$dir
 .DS_Store
 ._.DS_Store
 scoop.sublime-workspace

--- a/bucket/r.json
+++ b/bucket/r.json
@@ -1,9 +1,9 @@
 {
 	"homepage": "http://www.r-project.org",
-	"version": "3.1.1",
+	"version": "3.2.2",
 	"license": "GPL2",
-	"url": "http://cran.rstudio.com/bin/windows/base/R-3.1.1-win.exe",
-	"hash": "ce6fb76612aefc482583fb92f4f5c3cb8e8e3bf1a8dda97df7ec5caf746e53fe",
+	"url": "https://cran.rstudio.com/bin/windows/base/R-3.2.2-win.exe",
+	"hash": "c5ea69d2142b65fc798ef3516c5f669d761010d065a743661341b66825d8348b",
 	"innosetup": true,
 	"bin": [
 		"bin\\r.exe",
@@ -19,7 +19,7 @@ You can remove Powershell's 'r' command with:
 Annoying, right?! You might want to check out Pshazz (scoop install pshazz)--this has a plugin to remove some crazy aliases from Powershell, as well as many other improvements.
 ",
 	"checkver": {
-		"url": "http://cran.rstudio.com/bin/windows/base/",
+		"url": "https://cran.rstudio.com/bin/windows/base/",
 		"re": "<h1>R-([0-9\\.]+)"
 	}
 }


### PR DESCRIPTION
`scoop install r` was failing because `R-3.1.1-win.exe` is no longer on the RStudio server, so I updated r.json to fetch R 3.2.2.

R installation still doesn't work for me, however. I'll write up the issue.
